### PR TITLE
Add Fusion 360 script for cleaning document version suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # NameTagger
-Autodesk Fusion script/addon for controlling or modifying filename suffix
+
+A simple Fusion 360 add-in that cleans up document names by removing
+trailing version numbers (e.g. `v1`, `v23`) whenever a document is
+saved. This does not disable Fusion 360's versioning; it only keeps the
+names shown in the browser and exported files tidy.
+
+## Usage
+
+1. Copy `rename_on_save.py` into your Fusion 360 Scripts or Add-Ins
+   folder.
+2. In Fusion 360, open the Add-Ins dialog and run the script.
+3. While active, every time a document is saved its name will be checked
+   and any version suffix will be stripped.
+4. Stop the add-in to restore the default behaviour.
+
+The core logic resides in the `remove_version_number` function which
+uses a regular expression to remove a suffix of the form `v<number>`.
+

--- a/rename_on_save.py
+++ b/rename_on_save.py
@@ -1,0 +1,56 @@
+import adsk.core
+import adsk.fusion
+import traceback
+import re
+
+handlers = []
+
+def remove_version_number(name: str) -> str:
+    """Remove trailing version suffix like 'v1', 'v23', etc."""
+    return re.sub(r"\s*v\d+$", "", name)
+
+
+class DocumentSavingHandler(adsk.core.DocumentEventHandler):
+    """Event handler that cleans document names on save."""
+
+    def notify(self, args: adsk.core.DocumentEventArgs):
+        try:
+            doc = args.document
+            original = doc.name
+            clean = remove_version_number(original)
+            if original != clean:
+                doc.name = clean
+                adsk.core.Application.get().log(
+                    f"Renamed document from '{original}' to '{clean}'"
+                )
+        except Exception:
+            adsk.core.Application.get().log(
+                "Failed:\n{}".format(traceback.format_exc())
+            )
+
+
+def run(context):
+    app = None
+    try:
+        app = adsk.core.Application.get()
+        handler = DocumentSavingHandler()
+        app.documentSaving.add(handler)
+        handlers.append(handler)
+        app.log("NameTagger started. Documents will be cleaned on save.")
+    except Exception:
+        if app:
+            app.log("Failed:\n{}".format(traceback.format_exc()))
+
+
+def stop(context):
+    app = None
+    try:
+        app = adsk.core.Application.get()
+        for h in handlers:
+            app.documentSaving.remove(h)
+        handlers.clear()
+        app.log("NameTagger stopped.")
+    except Exception:
+        if app:
+            app.log("Failed:\n{}".format(traceback.format_exc()))
+


### PR DESCRIPTION
## Summary
- add `rename_on_save.py` to remove `v1` style suffixes when saving Fusion 360 documents
- expand README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68841885cdc48327871b4a9f960dca7e