### PR TITLE
Add settings dialog for customizable renaming

### DIFF
--- a/NameTagger/NameTagger.py
+++ b/NameTagger/NameTagger.py
@@ -2,22 +2,54 @@ import adsk.core
 import adsk.fusion
 import traceback
 import re
+import datetime
 
 handlers = []
 
-def remove_version_number(name: str) -> str:
-    """Remove trailing version suffix like 'v1', 'v23', etc."""
-    return re.sub(r"\s*v\d+$", "", name)
+# User configurable settings with sensible defaults. These values are modified
+# through the settings command created below.
+settings = {
+    "auto_rename": True,
+    "strategy": "remove",  # remove | timestamp | revision
+    "regex": r"\s*v\d+$",
+    "export_path": "",
+}
+
+# IDs used for the command and UI elements so we can clean them up properly.
+CMD_ID = "NameTaggerSettingsCmd"
+_cmd_def = None
+_btn_ctrl = None
+_doc_handler = None
+
+def rename_document(name: str, doc) -> str:
+    """Apply the selected renaming strategy to ``name``."""
+    pattern = settings.get("regex", r"\s*v\d+$")
+    if not re.search(pattern, name):
+        return name
+
+    strategy = settings.get("strategy", "remove")
+    if strategy == "timestamp":
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        return re.sub(pattern, ts, name)
+    elif strategy == "revision":
+        rev = getattr(doc, "revisionId", "1")
+        base = re.sub(pattern, "", name)
+        return f"r{rev}_{base}"
+
+    # Default behaviour is to remove the suffix
+    return re.sub(pattern, "", name)
 
 
 class DocumentSavingHandler(adsk.core.DocumentEventHandler):
     """Event handler that cleans document names on save."""
 
     def notify(self, args: adsk.core.DocumentEventArgs):
+        if not settings.get("auto_rename", True):
+            return
         try:
             doc = args.document
             original = doc.name
-            clean = remove_version_number(original)
+            clean = rename_document(original, doc)
             if original != clean:
                 doc.name = clean
                 adsk.core.Application.get().log(
@@ -29,13 +61,109 @@ class DocumentSavingHandler(adsk.core.DocumentEventHandler):
             )
 
 
+class SettingsCommandExecuteHandler(adsk.core.CommandEventHandler):
+    """Reads values from the dialog and stores them in ``settings``."""
+
+    def notify(self, args: adsk.core.CommandEventArgs):
+        cmd = args.firingEvent.sender
+        inputs = cmd.commandInputs
+        settings["auto_rename"] = inputs.itemById("autoRename").value
+        settings["regex"] = inputs.itemById("regex").value
+        settings["export_path"] = inputs.itemById("exportPath").value
+        strat = inputs.itemById("strategy").selectedItem.name
+        settings["strategy"] = {
+            "Remove": "remove",
+            "Timestamp": "timestamp",
+            "Revision Prefix": "revision",
+        }.get(strat, "remove")
+
+
+class SettingsInputChangedHandler(adsk.core.InputChangedEventHandler):
+    """Updates the regex preview when inputs change."""
+
+    def notify(self, args: adsk.core.InputChangedEventArgs):
+        try:
+            cmd = args.firingEvent.sender
+            inputs = cmd.commandInputs
+            regex_val = inputs.itemById("regex").value
+            test_name = inputs.itemById("testName").value
+            strategy = inputs.itemById("strategy").selectedItem.name
+            tmp_settings = dict(settings)
+            tmp_settings["regex"] = regex_val
+            tmp_settings["strategy"] = {
+                "Remove": "remove",
+                "Timestamp": "timestamp",
+                "Revision Prefix": "revision",
+            }.get(strategy, "remove")
+
+            class _Dummy:
+                revisionId = "1"
+
+            preview = rename_document(test_name, _Dummy())
+            inputs.itemById("preview").text = preview
+        except Exception:
+            adsk.core.Application.get().log(
+                "Preview failed:\n{}".format(traceback.format_exc())
+            )
+
+
+class SettingsCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
+    """Builds the settings dialog."""
+
+    def notify(self, args: adsk.core.CommandCreatedEventArgs):
+        cmd = args.command
+        on_execute = SettingsCommandExecuteHandler()
+        cmd.execute.add(on_execute)
+        handlers.append(on_execute)
+
+        on_input = SettingsInputChangedHandler()
+        cmd.inputChanged.add(on_input)
+        handlers.append(on_input)
+
+        inputs = cmd.commandInputs
+        inputs.addBoolValueInput("autoRename", "Enable Auto Rename", True, "", settings["auto_rename"])
+
+        dd = inputs.addDropDownCommandInput(
+            "strategy", "Rename Strategy", adsk.core.DropDownStyles.TextListDropDownStyle
+        )
+        dd.listItems.add("Remove", settings["strategy"] == "remove")
+        dd.listItems.add("Timestamp", settings["strategy"] == "timestamp")
+        dd.listItems.add("Revision Prefix", settings["strategy"] == "revision")
+
+        inputs.addStringValueInput("regex", "Regex Pattern", settings["regex"])
+        inputs.addStringValueInput("testName", "Test Name", "MyFile v1")
+        inputs.addTextBoxCommandInput("preview", "Result", "", 1, True)
+        inputs.addStringValueInput("exportPath", "Export Path", settings["export_path"])
+
+
 def run(context):
+    global _cmd_def, _btn_ctrl, _doc_handler
     app = None
     try:
         app = adsk.core.Application.get()
-        handler = DocumentSavingHandler()
-        app.documentSaving.add(handler)
-        handlers.append(handler)
+        ui = app.userInterface
+
+        # document save handler
+        _doc_handler = DocumentSavingHandler()
+        app.documentSaving.add(_doc_handler)
+        handlers.append(_doc_handler)
+
+        # create the settings command definition
+        _cmd_def = ui.commandDefinitions.itemById(CMD_ID)
+        if not _cmd_def:
+            _cmd_def = ui.commandDefinitions.addButtonDefinition(
+                CMD_ID, "NameTagger Settings", "Configure NameTagger"
+            )
+
+        on_created = SettingsCommandCreatedHandler()
+        _cmd_def.commandCreated.add(on_created)
+        handlers.append(on_created)
+
+        addins_panel = ui.allToolbarPanels.itemById("SolidScriptsAddinsPanel")
+        _btn_ctrl = addins_panel.controls.itemById(CMD_ID)
+        if not _btn_ctrl:
+            _btn_ctrl = addins_panel.controls.addCommand(_cmd_def)
+
         app.log("NameTagger started. Documents will be cleaned on save.")
     except Exception:
         if app:
@@ -43,11 +171,22 @@ def run(context):
 
 
 def stop(context):
+    global _cmd_def, _btn_ctrl, _doc_handler
     app = None
     try:
         app = adsk.core.Application.get()
-        for h in handlers:
-            app.documentSaving.remove(h)
+        ui = app.userInterface
+
+        if _doc_handler:
+            app.documentSaving.remove(_doc_handler)
+            _doc_handler = None
+        if _btn_ctrl:
+            _btn_ctrl.deleteMe()
+            _btn_ctrl = None
+        if _cmd_def:
+            _cmd_def.deleteMe()
+            _cmd_def = None
+
         handlers.clear()
         app.log("NameTagger stopped.")
     except Exception:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # NameTagger
 
-A simple Fusion 360 add-in that cleans up document names by removing trailing
-version numbers (e.g. `v1`, `v23`) whenever a document is saved. This does not
-disable Fusion 360's versioning; it only keeps the names shown in the browser
-and exported files tidy.
+A simple Fusion 360 add-in that cleans up document names when they are saved.
+By default it removes trailing version numbers such as `v1` or `v23`, but the
+behaviour can be customised through the provided settings dialog.
 
 ## Usage
 
 1. Copy the entire `NameTagger` folder into your Fusion 360 **AddIns** directory.
 2. Restart Fusion 360 or open the Add-Ins dialog and run **NameTagger**.
-3. While active, every time a document is saved its name will be checked and any
-   version suffix will be stripped.
-4. Stop the add-in to restore the default behaviour.
+3. While active, every time a document is saved its name will be processed using
+   the selected strategy.
+4. Click **NameTagger Settings** in the ADD-INS panel to change options such as
+   enabling/disabling auto rename, choosing the rename strategy, providing a
+   custom regular expression or export path, and testing the regex.
+5. Stop the add-in to restore the default behaviour.
 
-The core logic resides in the `remove_version_number` function which uses a
-regular expression to remove a suffix of the form `v<number>`.
+The core logic resides in the `rename_document` function. It applies the chosen
+strategy based on the regular expression pattern entered in the settings dialog.


### PR DESCRIPTION
## Summary
- allow enabling/disabling auto rename
- support rename strategies: remove, timestamp and revision prefix
- preview regex results with a tester
- store export path preference
- update README for the new behaviour

## Testing
- `python3 -m py_compile NameTagger/NameTagger.py`

------
https://chatgpt.com/codex/tasks/task_e_68841e508d3c8327a5ced4ea31a50691